### PR TITLE
Pin `JamesIves/github-pages-deploy-action` to `v4.6.4`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,6 @@ jobs:
           modules: ${{ github.event.inputs.modules }}
 
       - name: Push
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@v4.6.4
         with:
           folder: build


### PR DESCRIPTION
## Description

Pin `JamesIves/github-pages-deploy-action` to `v4.6.4` due to a bug in the new release that causes 

```
Run JamesIves/github-pages-deploy-action@v4
Error: File not found: '/home/runner/work/_actions/JamesIves/github-pages-deploy-action/v4/lib/main.js'
```

## References

- https://github.com/JamesIves/github-pages-deploy-action/issues/1697